### PR TITLE
Only send to each person 1 time

### DIFF
--- a/paymentHandler.py
+++ b/paymentHandler.py
@@ -12,7 +12,8 @@ class ilpTrigger:
 		reward=bounty * unit // len(validators)
 		validators_as_string = ""
 		for v in validators:
-			validators_as_string+="{0}\n".format(v)
+			if not v in validators_as_string:
+				validators_as_string+="{0}\n".format(v)
 		with open('reward.txt', 'w') as logfile:
 			logfile.write(str(reward))
 		with open('validators.txt', 'w') as logfile:


### PR DESCRIPTION
Somehow I am getting multiple instances of the payment pointer in my list sometimes. Without checking if I've already included the validator, they will receive 2x the bounty that should. This is a workaround until I can identify the root cause of the issue (writing 2x to the validators.txt file)